### PR TITLE
Resolve duplicate root endpoint causing 502 errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -434,10 +434,6 @@ async def try_load_pytorch_model(model_dir):
         logger.warning(f"PyTorch model loading failed: {e}")
         return False
 
-@app.get("/")
-async def root():
-    return {"message": "Hazard Detection Backend API", "status": "running"}
-
 # Helper functions for OpenVINO inference
 def preprocess_image(image, input_shape):
     """


### PR DESCRIPTION
## Summary
- remove duplicate `/` GET endpoint to avoid FastAPI route conflict

## Testing
- `python -m py_compile app.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c6886d9948331aa9a1d147e2df0a3