### PR TITLE
Use uvicorn runtime in Railway config

### DIFF
--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -96,7 +96,7 @@ Expected response:
 builder = "nixpacks"  # Uses Railway's Nixpacks for automatic builds
 
 [deploy]
-startCommand = "python app.py"       # Starts the FastAPI server
+startCommand = "uvicorn app:app --host 0.0.0.0 --port $PORT"  # Starts the FastAPI server
 healthcheckPath = "/health"          # Railway monitors this endpoint
 healthcheckTimeout = 300             # 5 minutes timeout for health checks
 restartPolicyType = "ON_FAILURE"     # Restart only on failures

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "python app.py"
+startCommand = "uvicorn app:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- run FastAPI with uvicorn in Railway deploy config
- document new uvicorn start command in Railway deployment guide

## Testing
- `python -m py_compile app.py`
- `python test_api.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688cdcceb6788331b91d0edd87b8e8d5