### PR TITLE
Use uvicorn runtime in Railway config

### DIFF
--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -42,12 +42,12 @@ Set these in Railway Dashboard → Your Project → Variables:
 
 #### Required Variables
 ```bash
-PORT=8000
 RAILWAY_ENVIRONMENT_NAME=production
 MODEL_DIR=/app
 MODEL_BACKEND=auto
 PYTHONPATH=/app
 ```
+Railway automatically provides the `PORT` environment variable, so you don't need to set it manually.
 
 #### Optional API Service Variables
 ```bash
@@ -96,7 +96,7 @@ Expected response:
 builder = "nixpacks"  # Uses Railway's Nixpacks for automatic builds
 
 [deploy]
-startCommand = "python app.py"       # Starts the FastAPI server
+startCommand = "uvicorn app:app --host 0.0.0.0 --port $PORT"  # Starts the FastAPI server
 healthcheckPath = "/health"          # Railway monitors this endpoint
 healthcheckTimeout = 300             # 5 minutes timeout for health checks
 restartPolicyType = "ON_FAILURE"     # Restart only on failures
@@ -106,7 +106,6 @@ restartPolicyMaxRetries = 3          # Maximum restart attempts
 MODEL_DIR = "/app"                   # Model files location
 MODEL_BACKEND = "auto"               # Auto-select best backend
 PYTHONPATH = "/app"                  # Python path configuration
-PORT = "8000"                        # Service port
 RAILWAY_ENVIRONMENT_NAME = "production"  # Environment identifier
 ```
 

--- a/README.md
+++ b/README.md
@@ -384,11 +384,11 @@ The test suite checks:
 
 3. **Set Environment Variables** (in Railway dashboard)
    ```bash
-   PORT=8000
    MODEL_BACKEND=auto
    MODEL_DIR=/app
    RAILWAY_ENVIRONMENT_NAME=production
    ```
+   Railway automatically sets the `PORT` value for you.
 
 4. **Your API will be available at:**
    ```

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "python app.py"
+startCommand = "uvicorn app:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
@@ -12,5 +12,4 @@ restartPolicyMaxRetries = 3
 MODEL_DIR = "/app"
 MODEL_BACKEND = "auto"
 PYTHONPATH = "/app"
-PORT = "8000"
 RAILWAY_ENVIRONMENT_NAME = "production"


### PR DESCRIPTION
## Summary
- run FastAPI with uvicorn in Railway deploy config
- rely on Railway's assigned port instead of hardcoding `PORT`
- document automatic port assignment in Railway guide and README

## Testing
- `python -m py_compile app.py`
- `python test_api.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688cdcceb6788331b91d0edd87b8e8d5