### PR TITLE
fix: use pydantic-settings for config

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,7 +6,8 @@ Uses Pydantic Settings for environment-based configuration
 import os
 from pathlib import Path
 from typing import List, Optional, Literal
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -79,9 +80,7 @@ class Settings(BaseSettings):
     # Health check settings
     healthcheck_timeout: int = Field(default=120, env="HEALTHCHECK_TIMEOUT")
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
 
 class ModelConfig:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 pydantic==2.5.0
+pydantic-settings==2.0.3
 python-dotenv==1.0.0
 
 # Image processing and computer vision


### PR DESCRIPTION
## Summary
- use `pydantic-settings` for BaseSettings import
- configure `SettingsConfigDict` for env file support
- add pydantic-settings dependency

## Testing
- `pytest -q` *(fails: 20 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68936fcf91d08331b7898b564ff4cace