### PR TITLE
Set model input size to 480

### DIFF
--- a/API_FETCH_GUIDE.md
+++ b/API_FETCH_GUIDE.md
@@ -621,7 +621,7 @@ processBatchWithProgress(imageFiles, (progress) => {
       "Longitudinal Crack", "Manhole", "Patch Repair", "Pothole",
       "Transverse Crack", "Wheel Mark Crack"
     ],
-    "input_size": 512
+    "input_size": 480
   }
 }
 ```

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     model_backend: Literal["auto", "openvino", "pytorch"] = Field(
         default="auto", env="MODEL_BACKEND"
     )
-    model_input_size: int = Field(default=512, env="MODEL_INPUT_SIZE")
+    model_input_size: int = Field(default=480, env="MODEL_INPUT_SIZE")
 
     # OpenVINO settings
     openvino_device: str = Field(default="AUTO", env="OPENVINO_DEVICE")

--- a/app/models/api_models.py
+++ b/app/models/api_models.py
@@ -69,7 +69,7 @@ class Detection(BaseModel):
 class ImageSize(BaseModel):
     """Image dimensions"""
 
-    width: int = Field(..., example=640)
+    width: int = Field(..., example=480)
     height: int = Field(..., example=480)
 
 
@@ -82,7 +82,7 @@ class ModelInfo(BaseModel):
     class_count: int = Field(..., example=10)
     confidence_threshold: Optional[float] = Field(None, example=0.6)
     tracking_enabled: Optional[bool] = Field(None, example=True)
-    input_shape: Optional[List[int]] = Field(None, example=[1, 3, 512, 512])
+    input_shape: Optional[List[int]] = Field(None, example=[1, 3, 480, 480])
     output_shape: Optional[List[int]] = Field(None, example=[1, 25200, 15])
     device: Optional[str] = Field(None, example="AUTO")
     performance_mode: Optional[str] = Field(None, example="LATENCY")
@@ -224,7 +224,7 @@ class DeviceInfo(BaseModel):
     """Device information"""
 
     device: Optional[str] = Field(None, example="AUTO")
-    input_shape: Optional[List[int]] = Field(None, example=[1, 3, 512, 512])
+    input_shape: Optional[List[int]] = Field(None, example=[1, 3, 480, 480])
     output_shape: Optional[List[int]] = Field(None, example=[1, 25200, 15])
     model_path: Optional[str] = Field(
         None, example="best0408_openvino_model/best0408.xml"
@@ -257,7 +257,7 @@ class ModelFiles(BaseModel):
     pytorch_model: str = Field(..., example="/app/best.pt")
     current_backend: str = Field(..., example="openvino")
     model_classes: int = Field(..., example=10)
-    input_size: int = Field(..., example=512)
+    input_size: int = Field(..., example=480)
 
 
 class ConfigurationInfo(BaseModel):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -31,8 +31,8 @@ def client():
 @pytest.fixture
 def test_image():
     """Create a test image"""
-    # Create a simple 640x640 RGB test image
-    img_array = np.random.randint(0, 255, (640, 640, 3), dtype=np.uint8)
+    # Create a simple 480x480 RGB test image
+    img_array = np.random.randint(0, 255, (480, 480, 3), dtype=np.uint8)
     img = Image.fromarray(img_array, "RGB")
 
     # Convert to bytes
@@ -127,7 +127,7 @@ class MockOpenVinoModel:
     """Mock OpenVINO model for testing"""
 
     def __init__(self):
-        self.input_shape = [1, 3, 512, 512]
+        self.input_shape = [1, 3, 480, 480]
         self.output_shape = [1, 25200, 15]  # YOLO output format
 
     def predict(self, image):
@@ -144,7 +144,7 @@ def mock_openvino_model():
 
 
 # Test data constants
-TEST_IMAGE_WIDTH = 640
-TEST_IMAGE_HEIGHT = 640
+TEST_IMAGE_WIDTH = 480
+TEST_IMAGE_HEIGHT = 480
 TEST_CONFIDENCE_THRESHOLD = 0.5
 TEST_IOU_THRESHOLD = 0.45

--- a/app/tests/test_detection_api.py
+++ b/app/tests/test_detection_api.py
@@ -277,7 +277,7 @@ def test_detect_best0408_openvino_model(
             "Wheel Mark Crack",
         ],
         "class_count": 10,
-        "input_shape": [1, 3, 512, 512],
+        "input_shape": [1, 3, 480, 480],
         "output_shape": [1, 25200, 15],
         "device": "AUTO",
         "performance_mode": "LATENCY",

--- a/app/tests/test_model_service.py
+++ b/app/tests/test_model_service.py
@@ -100,7 +100,7 @@ class TestModelService:
         mock_model.outputs = [mock_output_layer]
         mock_input_layer.partial_shape.is_dynamic = False
         mock_output_layer.partial_shape.is_dynamic = False
-        mock_input_layer.shape = [1, 3, 512, 512]
+        mock_input_layer.shape = [1, 3, 480, 480]
         mock_output_layer.shape = [1, 25200, 15]
 
         mock_compiled_model.input.return_value = mock_input_layer
@@ -183,7 +183,7 @@ class TestModelService:
         mock_model.predict.return_value = [mock_result]
         service.model = mock_model
 
-        test_image = Image.new("RGB", (640, 640))
+        test_image = Image.new("RGB", (480, 480))
 
         with patch("app.services.model_service.model_config") as mock_config:
             mock_config.class_names = [
@@ -265,7 +265,7 @@ class TestModelService:
         # Mock OpenVINO components
         mock_input_layer = MagicMock()
         mock_output_layer = MagicMock()
-        mock_input_layer.shape = [1, 3, 512, 512]
+        mock_input_layer.shape = [1, 3, 480, 480]
         mock_output_layer.shape = [1, 25200, 15]
         service.input_layer = mock_input_layer
         service.output_layer = mock_output_layer
@@ -283,7 +283,7 @@ class TestModelService:
 
         assert info["status"] == "loaded"
         assert info["backend"] == "openvino"
-        assert info["input_shape"] == [1, 3, 512, 512]
+        assert info["input_shape"] == [1, 3, 480, 480]
         assert info["output_shape"] == [1, 25200, 15]
         assert info["device"] == "AUTO"
         assert info["performance_mode"] == "LATENCY"


### PR DESCRIPTION
## Summary
- default model input size set to 480px
- adjust tests and schema examples for 480 input size

## Testing
- `pytest -q` *(fails: 20 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689377fcd2e88331812b5129c810c927