### PR TITLE
Handle health-check OPTIONS requests

### DIFF
--- a/app/api/health.py
+++ b/app/api/health.py
@@ -4,7 +4,7 @@ Health check and status API endpoints
 
 import platform
 from typing import Dict, Any
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 
 from ..core.config import settings
 from ..core.logging_config import get_logger
@@ -22,6 +22,12 @@ router = APIRouter(prefix="", tags=["health"])
 async def health_check():
     """Simple health check endpoint"""
     return {"status": "healthy"}
+
+
+@router.options("/health", include_in_schema=False)
+async def health_options() -> Response:
+    """Handle OPTIONS requests for health checks"""
+    return Response(status_code=200)
 
 
 @router.get("/")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,10 +49,8 @@ class Settings(BaseSettings):
     tracking_time_threshold: float = Field(default=2.0, env="TRACKING_TIME_THRESHOLD")
 
     # CORS settings
-    cors_origins: List[str] = Field(
-        default=["https://*.railway.app"], env="CORS_ORIGINS"
-    )
-    cors_methods: List[str] = Field(default=["GET", "POST"], env="CORS_METHODS")
+    cors_origins: List[str] = Field(default=["*"], env="CORS_ORIGINS")
+    cors_methods: List[str] = Field(default=["*"], env="CORS_METHODS")
     cors_headers: List[str] = Field(default=["*"], env="CORS_HEADERS")
 
     # External API credentials


### PR DESCRIPTION
## Summary
- broaden default CORS settings to allow all origins, methods, and headers
- respond to OPTIONS /health with a 200 to satisfy preflight checks

## Testing
- `pytest` *(fails: test_detect_no_session_id_error, test_detect_success_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68939fa91f5c8331b1c3749f888f7e0d