### PR TITLE
docs: update URLs for railway deployment

### DIFF
--- a/API_FETCH_GUIDE.md
+++ b/API_FETCH_GUIDE.md
@@ -6,7 +6,7 @@ This comprehensive guide shows you how to interact with the Hazard Detection API
 
 ```javascript
 // Production (Railway) - default
-const API_BASE_URL = process.env.HAZARD_API_URL || "https://hazard-api-production-production.up.railway.app:8000";
+const API_BASE_URL = process.env.HAZARD_API_URL || "https://hazard-api-production-production.up.railway.app";
 
 // Local Development
 // const API_BASE_URL = "http://localhost:8080";
@@ -38,7 +38,7 @@ const checkHealth = async () => {
 
 ```bash
 # cURL Example
-curl -X GET "https://hazard-api-production-production.up.railway.app:8000/health"
+curl -X GET "https://hazard-api-production-production.up.railway.app/health"
 ```
 
 **Response:**
@@ -81,7 +81,7 @@ const startSession = async () => {
 ```
 
 ```bash
-curl -X POST "https://hazard-api-production-production.up.railway.app:8000/session/start" \
+curl -X POST "https://hazard-api-production-production.up.railway.app/session/start" \
   -H "Content-Type: application/json"
 ```
 
@@ -130,7 +130,7 @@ const detectHazards = async (sessionId, imageFile) => {
 ```
 
 ```bash
-curl -X POST "https://hazard-api-production-production.up.railway.app:8000/" \
+curl -X POST "https://hazard-api-production-production.up.railway.app/detect/$SESSION_ID" \
   -F "file=@road_image.jpg"
 ```
 
@@ -311,7 +311,7 @@ const FormData = require('form-data');
 const fs = require('fs');
 
 class HazardDetectionClient {
-  constructor(baseUrl = process.env.HAZARD_API_URL || 'https://hazard-api-production-production.up.railway.app:8000') {
+  constructor(baseUrl = process.env.HAZARD_API_URL || 'https://hazard-api-production-production.up.railway.app') {
     this.baseUrl = baseUrl;
     this.sessionId = null;
   }
@@ -440,7 +440,7 @@ from typing import List, Dict, Optional
 
 class HazardDetectionClient:
     def __init__(self, base_url: str = None):
-        self.base_url = base_url or os.getenv("HAZARD_API_URL", "https://hazard-api-production-production.up.railway.app:8000")
+        self.base_url = base_url or os.getenv("HAZARD_API_URL", "https://hazard-api-production-production.up.railway.app")
         self.session_id = None
     
     async def start_session(self) -> str:
@@ -497,7 +497,7 @@ class HazardDetectionClient:
 
 # Usage example
 async def process_road_images(image_paths: List[str]):
-    client = HazardDetectionClient("https://hazard-api-production-production.up.railway.app:8000")
+    client = HazardDetectionClient("https://hazard-api-production-production.up.railway.app")
     
     try:
         # Check health

--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -146,7 +146,7 @@ from typing import List, Dict, Optional
 
 class HazardDetectionClient:
     def __init__(self, base_url: str = None):
-        self.base_url = base_url or os.getenv('HAZARD_API_URL', 'http://localhost:8000')
+        self.base_url = base_url or os.getenv('HAZARD_API_URL', 'http://localhost:8080')
         self.session_id = None
     
     async def start_session(self) -> str:
@@ -227,7 +227,7 @@ const FormData = require('form-data');
 const fs = require('fs');
 
 class HazardDetectionClient {
-    constructor(baseUrl = process.env.HAZARD_API_URL || 'http://localhost:8000') {
+    constructor(baseUrl = process.env.HAZARD_API_URL || 'http://localhost:8080') {
         this.baseUrl = baseUrl;
         this.sessionId = null;
     }
@@ -439,7 +439,7 @@ If both services are on Railway, you can use internal networking:
 
 ```python
 # Use Railway's internal URL for faster communication
-INTERNAL_API_URL = f"http://{os.getenv('RAILWAY_SERVICE_NAME', 'hazard-detection-api')}:8000"
+INTERNAL_API_URL = f"http://{os.getenv('RAILWAY_SERVICE_NAME', 'hazard-detection-api')}:8080"
 ```
 
 ### Load Balancing & Scaling

--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ python main.py
 ```
 
 4. **Access Documentation**
-- API: http://localhost:8080
-- Interactive Docs: http://localhost:8080/docs
-- Performance Metrics: http://localhost:8080/metrics
+- Production API: https://hazard-api-production-production.up.railway.app
+- Interactive Docs: https://hazard-api-production-production.up.railway.app/docs
+- Performance Metrics: https://hazard-api-production-production.up.railway.app/metrics
+- Local API: http://localhost:8080
+- Local Docs: http://localhost:8080/docs
+- Local Metrics: http://localhost:8080/metrics
 
 ## ⚙️ Configuration
 

--- a/SERVICE_INTEGRATION.md
+++ b/SERVICE_INTEGRATION.md
@@ -4,15 +4,15 @@ To integrate the Hazard Detection API into your service, configure the base URL.
 
 ## Base URL
 
-- Production: `https://hazard-api-production-production.up.railway.app:8000`
-- Development: `http://localhost:8000`
+- Production: `https://hazard-api-production-production.up.railway.app`
+- Development: `http://localhost:8080`
 
 Set the `HAZARD_API_URL` environment variable to point your service to the appropriate instance:
 
 ```bash
-export HAZARD_API_URL=https://hazard-api-production-production.up.railway.app:8000
+export HAZARD_API_URL=https://hazard-api-production-production.up.railway.app
 # For local development
-# export HAZARD_API_URL=http://localhost:8000
+# export HAZARD_API_URL=http://localhost:8080
 ```
 
 Use this variable when making requests, for example:

--- a/build-api.sh
+++ b/build-api.sh
@@ -13,7 +13,7 @@ docker build -t hazard-detection-api:latest .
 
 echo "✅ API Docker image built successfully!"
 echo "🚀 To run locally:"
-echo "   docker run -p 8000:8000 hazard-detection-api:latest"
+echo "   docker run -p 8080:8080 hazard-detection-api:latest"
 echo ""
 echo "🌐 To deploy to Railway:"
 echo "   1. Push this folder to a separate Git repository"


### PR DESCRIPTION
## Summary
- update all guides and scripts to use the Railway production domain instead of localhost or port 8000
- document production and local endpoints in README
- fix build script to map port 8080

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b0d866d88331ab9f868f29493fa3