### PR TITLE
docs: add comprehensive client guide

### DIFF
--- a/API_FETCH_GUIDE.md
+++ b/API_FETCH_GUIDE.md
@@ -2,6 +2,8 @@
 
 This comprehensive guide shows you how to interact with the Hazard Detection API using JavaScript `fetch()`, `curl`, and other HTTP clients.
 
+For a step-by-step walkthrough of common client workflows, see the [Client Guide](CLIENT_GUIDE.md).
+
 ## 🌍 Base URLs
 
 ```javascript

--- a/API_IMPLEMENTATION_SUMMARY.md
+++ b/API_IMPLEMENTATION_SUMMARY.md
@@ -2,6 +2,8 @@
 
 ## ✅ Complete B1-B5 Implementation
 
+For instructions on consuming the API from external services, see the [Client Guide](CLIENT_GUIDE.md).
+
 ### B1. Structure & Config ✅
 - **Clean app layout**: `app/main_b3.py`, `app/routers/`, `app/services/`, `app/models/schemas.py`, `app/core/config.py`
 - **Environment validation**: All required vars validated on startup (REDIS_*, CLOUDINARY_*, ALLOWED_ORIGINS, MODEL_PATH)

--- a/CLIENT_GUIDE.md
+++ b/CLIENT_GUIDE.md
@@ -1,10 +1,13 @@
 # Hazard Detection API Client Guide
 
-This guide explains how to send images to the Hazard Detection API from a client application and interpret the results.
+This guide explains how to integrate with the Hazard Detection API from any client application.
+It covers starting sessions, uploading images, reading results, and computing bounding box
+metrics derived from the model output.
 
 ## Base URL
 
-Use the API base URL for your environment:
+Configure the API base URL for your environment. You can override it with the
+`HAZARD_API_URL` environment variable.
 
 ```text
 https://hazard-api-production-production.up.railway.app
@@ -74,7 +77,17 @@ Each detection item contains:
 - `confidence` – model confidence score (0–1)
 - `class_id` / `class_name` – predicted hazard type
 
-When using session-based detection, additional fields may include `new_reports` and `session_stats` for hazard tracking.
+### Deriving Bounding Box Metrics
+
+The API only returns the `bbox` array. Clients can compute box center and size as needed:
+
+```javascript
+const [x1, y1, x2, y2] = detection.bbox;
+const width = x2 - x1;
+const height = y2 - y1;
+const centerX = x1 + width / 2;
+const centerY = y1 + height / 2;
+```
 
 ## 4. End the Session
 
@@ -83,6 +96,34 @@ curl -X POST "$BASE_URL/session/$SESSION_ID/end"
 ```
 
 ## Example Clients
+
+### Node.js Quick Start
+
+```javascript
+const axios = require('axios');
+const FormData = require('form-data');
+const fs = require('fs');
+
+const API_URL = process.env.HAZARD_API_URL || 'https://hazard-api-production-production.up.railway.app';
+
+async function quickDetection() {
+  const formData = new FormData();
+  formData.append('file', fs.createReadStream('test-image.jpg'));
+  const res = await axios.post(`${API_URL}/detect`, formData, { headers: formData.getHeaders() });
+  res.data.detections.forEach((d, i) => {
+    const [x1, y1, x2, y2] = d.bbox;
+    const w = x2 - x1;
+    const h = y2 - y1;
+    const cx = x1 + w / 2;
+    const cy = y1 + h / 2;
+    console.log(`Hazard ${i + 1}: ${d.class_name} (${(d.confidence*100).toFixed(1)}%)`);
+    console.log(` bbox: [${x1.toFixed(1)}, ${y1.toFixed(1)}] → [${x2.toFixed(1)}, ${y2.toFixed(1)}]`);
+    console.log(` center: (${cx.toFixed(1)}, ${cy.toFixed(1)}) size: ${w.toFixed(1)} x ${h.toFixed(1)}`);
+  });
+}
+
+quickDetection();
+```
 
 ### Python
 
@@ -95,23 +136,16 @@ session = requests.post(f"{BASE_URL}/session/start").json()["session_id"]
 with open("road.jpg", "rb") as f:
     files = {"file": f}
     result = requests.post(f"{BASE_URL}/detect/{session}", files=files).json()
-print(result["detections"])
-```
-
-### JavaScript (fetch)
-
-```javascript
-const session = await fetch(`${BASE_URL}/session/start`, {method: 'POST'}).then(r => r.json());
-const form = new FormData();
-form.append('file', fileInput.files[0]);
-const res = await fetch(`${BASE_URL}/detect/${session.session_id}`, {method: 'POST', body: form});
-const data = await res.json();
-console.log(data.detections);
+for d in result["detections"]:
+    x1, y1, x2, y2 = d["bbox"]
+    w, h = x2 - x1, y2 - y1
+    cx, cy = x1 + w/2, y1 + h/2
+    print(d["class_name"], cx, cy, w, h)
 ```
 
 ## Further Reading
 
 - [API Fetch Guide](API_FETCH_GUIDE.md) – detailed endpoint reference
 - [Node.js Integration Guide](NODEJS_INTEGRATION_GUIDE.md) – reusable client library example
-- [examples/](examples/README.md) – ready‑to‑run scripts
-
+- [Endpoints Guide](ENDPOINTS_GUIDE.md) – image and plot retrieval
+- [examples/](examples/README.md) – ready-to-run scripts

--- a/ENDPOINTS_GUIDE.md
+++ b/ENDPOINTS_GUIDE.md
@@ -2,6 +2,8 @@
 
 This guide explains how to retrieve images and model response plots from a live detection session.
 
+For general API usage and sending detection requests, see the [Client Guide](CLIENT_GUIDE.md).
+
 ## Prerequisites
 1. Start a session using `POST /session/start`.
 2. Run detections with `POST /detect/{session_id}` to generate reports.

--- a/FRONTEND_MIGRATION_GUIDE.md
+++ b/FRONTEND_MIGRATION_GUIDE.md
@@ -2,6 +2,8 @@
 
 This guide explains how to update the frontend to use the new centralized report management API.
 
+For general client integration and response handling, see the [Client Guide](CLIENT_GUIDE.md).
+
 ## Overview
 
 The report management system has been migrated from the Node.js frontend to the FastAPI backend for:

--- a/NODEJS_INTEGRATION_GUIDE.md
+++ b/NODEJS_INTEGRATION_GUIDE.md
@@ -4,6 +4,8 @@
 
 This guide shows how external Node.js services can integrate with your OpenVINO-powered hazard detection API running at `https://hazard-api-production-production.up.railway.app`.
 
+For general client usage and response handling, start with the [Client Guide](CLIENT_GUIDE.md).
+
 ## 📋 Table of Contents
 
 1. [API Overview](#api-overview)

--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 This guide covers deploying the Hazard Detection API to Railway and integrating it with other services.
 
+For how clients can consume the deployed API, refer to the [Client Guide](CLIENT_GUIDE.md).
+
 ## 🚀 Quick Railway Deployment
 
 ### 1. Prerequisites

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ curl -X POST http://localhost:8080/detect/$SESSION_ID \
 curl http://localhost:8080/session/$SESSION_ID/summary | jq
 ```
 
-See [CLIENT_README.md](CLIENT_README.md) for a comprehensive client integration guide, including base64 uploads and JavaScript examples.
+See [CLIENT_GUIDE.md](CLIENT_GUIDE.md) for a comprehensive client integration guide, including base64 uploads and JavaScript examples.
 
 ## 🚀 Development
 

--- a/REALTIME_STREAMING_GUIDE.md
+++ b/REALTIME_STREAMING_GUIDE.md
@@ -2,6 +2,8 @@
 
 This guide explains how to use the Hazard Detection API to perform real-time monitoring of a stream of images.
 
+For an overview of client requests and response parsing, start with the [Client Guide](CLIENT_GUIDE.md).
+
 The API does not use WebSockets for real-time streaming. Instead, it supports a polling-based approach where a client-side script can watch a directory for new images and send them to the API for processing as they arrive. This is a simple and effective way to achieve real-time monitoring without the complexity of WebSockets.
 
 This guide is based on the `examples/realTimeMonitoring.js` script in this repository.

--- a/SERVICE_INTEGRATION.md
+++ b/SERVICE_INTEGRATION.md
@@ -2,6 +2,8 @@
 
 To integrate the Hazard Detection API into your service, configure the base URL.
 
+For detailed client examples and response handling, see the [Client Guide](CLIENT_GUIDE.md).
+
 ## Base URL
 
 - Production: `https://hazard-api-production-production.up.railway.app`

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # Node.js Examples for OpenVINO Hazard Detection API
 
 This directory contains practical examples showing how to integrate with the OpenVINO-powered hazard detection API running at `https://hazard-api-production-production.up.railway.app`.
+For a full walkthrough of client workflows, see the [Client Guide](../CLIENT_GUIDE.md).
 
 ## 🚀 Quick Setup
 
@@ -15,7 +16,7 @@ npm install axios form-data chokidar
 ## 📁 Examples Overview
 
 ### 1. Quick Start (`quickStart.js`)
-Simple single-image detection example - perfect for testing connectivity.
+Simple single-image detection example that logs bounding box coordinates, center, and size.
 
 ```bash
 npm run quick-start

--- a/examples/quickStart.js
+++ b/examples/quickStart.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 const FormData = require('form-data');
 const fs = require('fs');
 
-const API_URL = 'https://hazard-api-production-production.up.railway.app';
+const API_URL = process.env.HAZARD_API_URL || 'https://hazard-api-production-production.up.railway.app';
 
 async function quickDetection() {
   try {
@@ -46,11 +46,18 @@ async function quickDetection() {
 
     // Show each detected hazard
     result.detections.forEach((detection, index) => {
+      const [x1, y1, x2, y2] = detection.bbox;
+      const width = x2 - x1;
+      const height = y2 - y1;
+      const centerX = x1 + width / 2;
+      const centerY = y1 + height / 2;
+
       console.log(`\n🚨 Hazard ${index + 1}:`);
       console.log(`  Type: ${detection.class_name}`);
       console.log(`  Confidence: ${(detection.confidence * 100).toFixed(1)}%`);
-      console.log(`  Location: x=${Math.round(detection.center_x)}, y=${Math.round(detection.center_y)}`);
-      console.log(`  Size: ${Math.round(detection.width)} x ${Math.round(detection.height)} pixels`);
+      console.log(`  Bounding box: [${x1.toFixed(1)}, ${y1.toFixed(1)}] → [${x2.toFixed(1)}, ${y2.toFixed(1)}]`);
+      console.log(`  Center: (${centerX.toFixed(1)}, ${centerY.toFixed(1)})`);
+      console.log(`  Size: ${width.toFixed(1)} x ${height.toFixed(1)} pixels`);
     });
 
     if (result.detections.length === 0) {


### PR DESCRIPTION
## Summary
- add full client guide with code for deriving center and size from `bbox`
- read API base URL from `HAZARD_API_URL` in quick start example
- cross-link existing docs to new client guide

## Testing
- `pytest` *(fails: ModelLoadingException, KeyError 'id', others)*

------
https://chatgpt.com/codex/tasks/task_e_689721247cd08331bf29150c7286964e